### PR TITLE
Fixed broken images displayed on the org page

### DIFF
--- a/profile/readme.md
+++ b/profile/readme.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/kubb-project/kubb/main/assets/banner.png" alt="logo"  height="auto" />
+<img src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/banner.png" alt="logo"  height="auto" />
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -11,13 +11,13 @@
 </p>
 
 <h4>
-    <a href="https://codesandbox.io/s/github/kubb-project/kubb/tree/main/examples/typescript" target="_blank">View Demo</a>
+    <a href="https://codesandbox.io/s/github/kubb-labs/kubb/tree/main/examples/typescript" target="_blank">View Demo</a>
     <span> · </span>
       <a href="https://kubb.dev/" target="_blank">Documentation</a>
     <span> · </span>
-      <a href="https://github.com/kubb-project/kubb/issues/" target="_blank">Report Bug</a>
+      <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
     <span> · </span>
-      <a href="https://github.com/kubb-project/kubb/issues/" target="_blank">Request Feature</a>
+      <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Request Feature</a>
   </h4>
 </div>
 
@@ -26,7 +26,7 @@
 ## Features
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/kubb-project/kubb/main/assets/features.png" alt="features"  height="auto" />
+  <img src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/features.png" alt="features"  height="auto" />
 </div>
 
 ## Contributors [![Contributors][contributors-src]][contributors-href]
@@ -37,11 +37,11 @@
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.stijnvanhulle.be"><img src="https://avatars.githubusercontent.com/u/5904681?v=4?s=100" width="100px;" alt="Stijn Van Hulle"/><br /><sub><b>Stijn Van Hulle</b></sub></a><br /><a href="https://github.com/kubb-project/kubb/commits?author=stijnvanhulle" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://fosstodon.org/@xphentom"><img src="https://avatars.githubusercontent.com/u/5096867?v=4?s=100" width="100px;" alt="Wouter Roozeleer"/><br /><sub><b>Wouter Roozeleer</b></sub></a><br /><a href="https://github.com/kubb-project/kubb/commits?author=xPhentom" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://aluc.io/"><img src="https://avatars.githubusercontent.com/u/15520015?v=4?s=100" width="100px;" alt="Alfred"/><br /><sub><b>Alfred</b></sub></a><br /><a href="https://github.com/kubb-project/kubb/commits?author=b6pzeusbc54tvhw5jgpyw8pwz2x6gs" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/raveclassic"><img src="https://avatars.githubusercontent.com/u/1743568?v=4?s=100" width="100px;" alt="Kirill Agalakov"/><br /><sub><b>Kirill Agalakov</b></sub></a><br /><a href="https://github.com/kubb-project/kubb/commits?author=raveclassic" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://wicky.nillia.ms"><img src="https://avatars.githubusercontent.com/u/1091390?v=4?s=100" width="100px;" alt="Nick Williams"/><br /><sub><b>Nick Williams</b></sub></a><br /><a href="https://github.com/kubb-project/kubb/commits?author=WickyNilliams" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://www.stijnvanhulle.be"><img src="https://avatars.githubusercontent.com/u/5904681?v=4?s=100" width="100px;" alt="Stijn Van Hulle"/><br /><sub><b>Stijn Van Hulle</b></sub></a><br /><a href="https://github.com/kubb-labs/kubb/commits?author=stijnvanhulle" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fosstodon.org/@xphentom"><img src="https://avatars.githubusercontent.com/u/5096867?v=4?s=100" width="100px;" alt="Wouter Roozeleer"/><br /><sub><b>Wouter Roozeleer</b></sub></a><br /><a href="https://github.com/kubb-labs/kubb/commits?author=xPhentom" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://aluc.io/"><img src="https://avatars.githubusercontent.com/u/15520015?v=4?s=100" width="100px;" alt="Alfred"/><br /><sub><b>Alfred</b></sub></a><br /><a href="https://github.com/kubb-labs/kubb/commits?author=b6pzeusbc54tvhw5jgpyw8pwz2x6gs" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/raveclassic"><img src="https://avatars.githubusercontent.com/u/1743568?v=4?s=100" width="100px;" alt="Kirill Agalakov"/><br /><sub><b>Kirill Agalakov</b></sub></a><br /><a href="https://github.com/kubb-labs/kubb/commits?author=raveclassic" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="http://wicky.nillia.ms"><img src="https://avatars.githubusercontent.com/u/1091390?v=4?s=100" width="100px;" alt="Nick Williams"/><br /><sub><b>Nick Williams</b></sub></a><br /><a href="https://github.com/kubb-labs/kubb/commits?author=WickyNilliams" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>
@@ -60,11 +60,11 @@
 
 ## Star History
 
-<a href="https://star-history.com/#kubb-project/kubb&Date">
+<a href="https://star-history.com/#kubb-labs/kubb&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kubb-project/kubb&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kubb-project/kubb&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kubb-project/kubb&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date" />
   </picture>
 </a>
 
@@ -74,13 +74,13 @@
 [npm-version-href]: https://npmjs.com/package/@kubb/core
 [npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/core?flat&colorA=18181B&colorB=f58517
 [npm-downloads-href]: https://npmjs.com/package/@kubb/core
-[license-src]: https://img.shields.io/github/license/kubb-project/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-project/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-project/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
+[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
 [build-href]: https://www.npmjs.com/package/@kubb/core
 [minified-src]: https://img.shields.io/bundlephobia/min/@kubb/core?style=flat&colorA=18181B&colorB=f58517
 [minified-href]: https://www.npmjs.com/package/@kubb/core
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-project/kubb?style=flat&colorA=18181B&colorB=f58517
+[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
 [coverage-href]: https://www.npmjs.com/package/@kubb/core
 [contributors-src]: https://img.shields.io/github/contributors/stijnvanhulle/kubb?style=flat&colorA=18181B&colorB=f58517&label=%20
 [contributors-href]: #contributors-


### PR DESCRIPTION
Saw some broken images on your github org page where images still pointed to the old org name